### PR TITLE
Allow binding to a custom port

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -3,6 +3,7 @@ interface=
 root=example.com
 domain=dns.example.com
 host_ip=
+port=
 log=* # or the DNS request type, eg TXT
 
 [packets]

--- a/src/client.py
+++ b/src/client.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
 
 import sys
-import socket
 
-from scapy.layers.dns import DNS, DNSQR
-from scapy.layers.inet import IP, UDP, ICMP, IPerror
+from scapy.layers.dns import DNS, struct
+from scapy.layers.inet import UDP, ICMP, IPerror
 from scapy.sendrecv import sr1
 
 from converter import Domain, Content
 from packet import Packet
-from utils import DNSHeaders, init_logger, get_ip_from_hostname
+from utils import init_logger, get_ip_from_hostname
 
 
 logger = None
 
 
 class Client:
-    def __init__(self, domain: str, ip: str, verbosity: int = 0):
+    def __init__(self, domain: str, ip: str, port: int = 53, verbosity: int = 0):
         self.dns_server = ip
+        self.dns_server_port = port
         self.domain = domain
         self.verb = verbosity
 
@@ -25,13 +25,30 @@ class Client:
         crafted_domain = f"{Domain.encode(message)}.{self.domain}"
 
         packet = Packet.build_query(
-            {"dst": self.dns_server, "dns": {"qname": crafted_domain}}, self.domain,
+            {
+                "dst": self.dns_server,
+                "dport": self.dns_server_port,
+                "dns": {"qname": crafted_domain},
+            },
+            self.domain,
         )
         answer = sr1(packet.packet, verbose=self.verb, timeout=1)
         if answer.haslayer(ICMP) or answer.haslayer(IPerror):
             logger.debug(answer.show())
             logger.critical("Unreachable host or filtered port")
             return None
+
+        # if we are using a port other than 53, then scapy will not
+        # parse the DNS layer automatically
+        if DNS not in answer:
+            try:
+                dns_layer = DNS(answer[UDP].payload.load)
+            except struct.error:
+                logger.error("UDP payload of answer is not a valid DNS packet")
+                return None
+            answer[UDP].remove_payload()
+            answer /= dns_layer
+
         return answer[DNS] if answer is not None else None
 
     def recv(self, pkt: DNS):
@@ -51,13 +68,20 @@ class Client:
 if __name__ == "__main__":
     logger = init_logger()
     if len(sys.argv) < 2:
-        logger.error("Usage: %s hostname [message]", sys.argv[0])
+        logger.error("Usage: %s hostname[:port] [message]", sys.argv[0])
         sys.exit(-1)
 
-    ip = get_ip_from_hostname(sys.argv[1])
+    # seperate hostname and optional port
+    hostname_and_port = sys.argv[1].split(":")
+    hostname = hostname_and_port[0]
+    port = 53
+    if len(hostname_and_port) == 2:
+        port = int(hostname_and_port[1])
+
+    ip = get_ip_from_hostname(hostname)
     if ip is None:
         sys.exit(-1)
 
-    client = Client(sys.argv[1], ip)
+    client = Client(hostname, ip, port)
     pkt = client.send("hello world" if len(sys.argv) == 2 else sys.argv[2])
     client.recv(pkt)

--- a/src/packet.py
+++ b/src/packet.py
@@ -4,7 +4,7 @@ import operator as op
 from functools import reduce
 from random import randint
 
-from scapy.layers.dns import DNS, DNSQR, DNSRR, dnstypes
+from scapy.layers.dns import DNS, DNSQR, dnstypes
 from scapy.layers.inet import IP, UDP
 
 from utils import DNSHeaders
@@ -52,7 +52,7 @@ class Packet:
             object: a Packet object
         """
         pkt = IP(dst=layer["dst"], tos=build_tos(1, 0, 1, 0, 0))
-        pkt /= UDP(sport=randint(0, 2 ** 16 - 1), dport=53)
+        pkt /= UDP(sport=randint(0, 2 ** 16 - 1), dport=layer["dport"])
         pkt /= DNS(
             # random transaction id
             id=randint(0, 2 ** 16 - 1),
@@ -77,7 +77,7 @@ class Packet:
             object: a Packet object
         """
         pkt = IP(dst=layer["dst"], src=layer["src"])
-        pkt /= UDP(dport=layer["dport"], sport=53)
+        pkt /= UDP(dport=layer["dport"], sport=layer["sport"])
         pkt /= DNS(
             id=layer["dns"]["id"],
             qr=DNSHeaders.QR.Answer,


### PR DESCRIPTION
Add a way to specify a custom port for the DNS server to bind to.
This is useful when we are developing on our local machine and port 53 is already taken by another process like a local resolver (using DNSCrypt for example). 